### PR TITLE
fix: improve tutorial filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "plugin-image-zoom": "flexanalytics/plugin-image-zoom",
     "raw-loader": "^4.0.2",
     "react": "18.2.0",
-    "react-collapsible": "^2.8.4",
     "react-dom": "18.2.0",
     "react-flickity-component": "^3.6.3",
     "react-image-gallery": "^1.3.0",

--- a/src/components/TutorialFilters/index.tsx
+++ b/src/components/TutorialFilters/index.tsx
@@ -7,10 +7,10 @@ import { useAllPluginInstancesData } from '@docusaurus/useGlobalData';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import SearchBar, { readSearchName } from '../SearchBar';
 import { sortBy } from '@site/src/utils/jsUtils';
+import { Collapsible, useCollapsible } from '@docusaurus/theme-common';
 
 import './styles.css';
 
-import Collapsible from 'react-collapsible';
 import { NormalizedOptions as Tutorial } from '@iota-wiki/plugin-tutorial';
 import { TagCategories } from '@site/src/utils/tags';
 
@@ -119,15 +119,19 @@ export function prepareUserState(): UserState | undefined {
   return undefined;
 }
 
+export function useGetActiveTags() {
+  const location = useLocation();
+  return useMemo(() => readSearchTags(location.search), [location]);
+}
+
 export function useFilteredTutorials() {
   const location = useLocation<UserState>();
-  // On SSR / first mount (hydration) no tag is selected
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [searchName, setSearchName] = useState<string | null>(null);
+  // On SSR / first mount (hydration) no tag is selected
+  const selectedTags = useGetActiveTags();
   // Sync tags from QS to state (delayed on purpose to avoid SSR/Client
   // hydration mismatch)
   useEffect(() => {
-    setSelectedTags(readSearchTags(location.search));
     setSearchName(readSearchName(location.search));
     restoreUserState(location.state);
   }, [location]);
@@ -154,14 +158,14 @@ function TutorialFilters() {
   const history = useHistory();
   const filteredTutorials = useFilteredTutorials();
   const siteCountPlural = useSiteCountPlural();
-
-  const [isOpen, setIsOpen] = useState(false);
+  const { collapsed, toggleCollapsed } = useCollapsible({ initialState: true });
+  const collapsibleAnimation = { duration: 400, easing: 'linear' };
+  const selectedTags = useGetActiveTags();
 
   const changeTags = useCallback(
     (_, actionMeta) => {
       const items = getItems(actionMeta);
-      const tags = readSearchTags(location.search);
-      const newTags = toggleListItem(tags, items);
+      const newTags = toggleListItem(selectedTags, items);
       const newSearch = replaceSearchTags(location.search, newTags);
       history.push({
         ...location,
@@ -190,20 +194,34 @@ function TutorialFilters() {
         <SearchBar className='tutorial-filter__search' />
         <button
           className='button tutorial-filter__toggle'
-          onClick={() => setIsOpen(!isOpen)}
+          onClick={toggleCollapsed}
         >
           <span className='material-icons'>filter_list</span>
           <span className='tutorial-filter__toggle-label'>Filter</span>
         </button>
       </div>
-      <Collapsible trigger='' triggerDisabled={true} open={isOpen}>
-        <div className='row'>
-          {Array.from(TagCategories.entries()).map(([category, tags]) => (
-            <div className='col' key={category}>
-              <h5>{category}</h5>
-              <Select placeholder={category} options={tags} {...selectProps} />
-            </div>
-          ))}
+      <Collapsible
+        lazy={true}
+        collapsed={collapsed}
+        animation={collapsibleAnimation}
+      >
+        <div className='row tutorial-filters__row'>
+          {Array.from(TagCategories.entries()).map(([category, tags]) => {
+            const value = tags.filter((tag) =>
+              selectedTags.includes(tag.value),
+            );
+            return (
+              <div className='col' key={category}>
+                <h5>{category}</h5>
+                <Select
+                  placeholder={category}
+                  options={tags}
+                  {...selectProps}
+                  value={value}
+                />
+              </div>
+            );
+          })}
         </div>
       </Collapsible>
       <div className='row margin-vert--lg'>

--- a/src/components/TutorialFilters/styles.css
+++ b/src/components/TutorialFilters/styles.css
@@ -13,6 +13,10 @@
   justify-content: space-between;
 }
 
+.tutorial-filters__row {
+  padding-top: 20px;
+}
+
 .tutorial-filter__search {
   flex-grow: 1;
   max-width: 50%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2839,7 +2839,6 @@ __metadata:
     prettier: ^2.8.8
     raw-loader: ^4.0.2
     react: 18.2.0
-    react-collapsible: ^2.8.4
     react-dom: 18.2.0
     react-flickity-component: ^3.6.3
     react-image-gallery: ^1.3.0
@@ -14991,16 +14990,6 @@ plugin-image-zoom@flexanalytics/plugin-image-zoom:
     lodash.flow: ^3.3.0
     pure-color: ^1.2.0
   checksum: 00a12dddafc8a9025cca933b0dcb65fca41c81fa176d1fc3a6a9d0242127042e2c0a604f4c724a3254dd2c6aeb5ef55095522ff22f5462e419641c1341a658e4
-  languageName: node
-  linkType: hard
-
-"react-collapsible@npm:^2.8.4":
-  version: 2.10.0
-  resolution: "react-collapsible@npm:2.10.0"
-  peerDependencies:
-    react: ~15 || ~16 || ~17 || ~18
-    react-dom: ~15 || ~16 || ~17 || ~18
-  checksum: f7a883eb7c4aa91916378dfd4c98dc92a32bbdb4d6b8fad179e34ad1f2bbbab35446f5f6e126d699427bc67d1d70909c69f6be4ee744251bea4e17c7d10be2f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description of change

Remove unused package `react-collapsible` to use docusaurus' collapsible component and avoid showing collapsible contents.
Show selected filters on first load. Also fix a bug where the syncronization of queries and tags were incorrect after first load with tags selected.

## Links to any relevant issues

Closes #29.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix
- Enhancement

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the [contribution guidelines](https://github.com/iota-wiki/iota-wiki/blob/main/.github/CONTRIBUTING.md) for this project
- [x] I have performed a self-review of my own changes
